### PR TITLE
Update regex string for token extraction

### DIFF
--- a/BlueCatAPIClient/__init__.py
+++ b/BlueCatAPIClient/__init__.py
@@ -15,7 +15,7 @@ class Client(APIPlugin):
         session.headers = self.headers
         session.verify = self.verify
         response = session.get(f'{self.base_url}/login', params={'username': username, 'password': password})
-        token = re.search(r'->\s(\w+:\s\w+(?:==)?)\s<-', response.text, flags=re.I)
+        token = re.search(r'->\s(\w+:\s[\w+\/]+(?:==)?)\s<-', response.text, flags=re.I)
         if token:
             self.token = token.group(1)
             session.headers.update({'Authorization': self.token})


### PR DESCRIPTION
It seems like the later versions of Bluecat API can include extra characters in the returned token, specifically "/" and "+" from my experience.

This caused issues where the token was never extracted and all queries would then fail as token would be None.